### PR TITLE
[sugar] odstraneni mezery za carkou v en oddelovaci tisicu

### DIFF
--- a/tex/latex/fks/fkssugar.sty
+++ b/tex/latex/fks/fkssugar.sty
@@ -261,7 +261,7 @@
 
 \def\fkssug@renglish{%
 % tg can be used: https://en.wikipedia.org/wiki/Trigonometric_functions
-\mathchardef\carka=\mathcode`\,
+\mathchardef\carka="013B
 
 % decimal point
 	\def\jed@A ##1 {\begingroup\def~{\carka}\mathcode`\.="013A\mathcode`\,="013A \begingroup \mathcode`\e="8000 ##1 \jed@B} % numbers written with dot or comma


### PR DESCRIPTION
Drive se v anglictine $"1~000"$ vysazelo jako 1, 000, ale ma byt 1,000.