### PR TITLE
[bugfix] Don't break line before footnote mark

### DIFF
--- a/texmf/tex/latex/fks/fkssugar.sty
+++ b/texmf/tex/latex/fks/fkssugar.sty
@@ -94,9 +94,10 @@
 
 % footnote nad interpunkci
 \newcommand{\footnotei}[2]{%
+\mbox{%
 \setbox0\hbox{#1}%
 \copy0%
-\hspace{-\wd0}%
+\hspace{-\wd0}}%
 \footnote{#2}%
 }
 


### PR DESCRIPTION
Break line after fotenotei mark, not between interpuction and footenotei mark. Mbox fixed this issue.