### PR TITLE
Změna jména úlohy z C na V

### DIFF
--- a/texmf/tex/latex/fks/fksmeta.sty
+++ b/texmf/tex/latex/fks/fksmeta.sty
@@ -247,7 +247,7 @@ To view a copy of the license, visit
   \newcommand\seriesname[1]{\renewcommand\@seriesname{#1}}
   \renewcommand\met@headername{Korespondenční seminář MFF UK pro základní školy}
   \renewcommand\met@shortname{Výfuk}
-  \renewcommand\@metaprobletter[1]{\ifcase #1 \or 1\or 2\or 3\or 4\or 5\or E\or C\else \@ctrerr\fi}
+  \renewcommand\@metaprobletter[1]{\ifcase #1 \or 1\or 2\or 3\or 4\or 5\or E\or V\else \@ctrerr\fi}
   \renewcommand\metaprobdata[1]{%
 % Tags for study years (default are all)
 {\LARGE
@@ -440,7 +440,7 @@ Pro zobrazení kopie této licence navštivte
 }
 
 % results table parameter
-\renewcommand\met@probheader{1 & 2 & 3 & 4 & 5 & E & C} % results table problems header
+\renewcommand\met@probheader{1 & 2 & 3 & 4 & 5 & E & V} % results table problems header
 \renewcommand\met@resultscols{\newcolumntype{T}{x{\bfseries}rA{\itshape}p{0.22\textwidth}^X% order, name, school
 ^r^r^r^r^r^r^r%points columns
 @{\hspace{12pt}}A{\bfseries}r@{\hspace{8pt}}A{\bfseries}r}} % batch sum, sum


### PR DESCRIPTION
Vzhledem k tomu, že označení C pro úlohu zaměřené na výfučtení (zamýšleno jak "Cteni") bylo pro některé matoucí, rozhodli jsme se jméno této úlohy změnit na V (Výfučtení).