### PR TITLE
fkssugar: Use space as thousands separator

### DIFF
--- a/texmf/tex/latex/fks/fkssugar.sty
+++ b/texmf/tex/latex/fks/fkssugar.sty
@@ -268,7 +268,7 @@
 \mathchardef\carka="013B
 
 % decimal point
-	\def\jed@A ##1 {\begingroup\def~{\carka}\mathcode`\.="013A\mathcode`\,="013A \begingroup \mathcode`\e="8000 ##1 \jed@B} % numbers written with dot or comma
+	\def\jed@A ##1 {\begingroup\def~{\,}\mathcode`\.="013A\mathcode`\,="013A \begingroup \mathcode`\e="8000 ##1 \jed@B} % numbers written with dot or comma
 
 %quotation
 \ifdefined\uv\renewcommand\uv[1]{``##1''}\fi


### PR DESCRIPTION
There is no strict norm mandating comma as thousands separator in
English. As per [1] spaces are recommended.

Most importantly, it may be confusing when context is missing, e.g.
1,000 can be mistaked for 1.000 (1e3 vs 1e0).

[1] https://en.wikipedia.org/wiki/Decimal_separator#Current_standards