### PR TITLE
example update

### DIFF
--- a/texmf/doc/fks/jakpsat.tex
+++ b/texmf/doc/fks/jakpsat.tex
@@ -693,7 +693,6 @@ pomocí příkazu \texttt{pdflatex}).
 \usepackage[no-math]{fontspec}
 \usepackage{xltxtra,polyglossia}
 \setmainlanguage{czech} % dokument bude v češtině
-\mathcode`\,="013B % používá se desetinná čárka
 \usepackage{fkssugar} % FYKOS
 \usepackage[margin=2cm]{geometry} % okraje stránky
 \usepackage{color,graphicx,graphics} % barvičky, obrázky


### PR DESCRIPTION
Výraz
\mathcode`\,="013B
předefinuje všechny čárky v matematickém módu tak, že za nimi už nebudou mezery. To je velmi nepraktické například u vektorů nebo obecně při výčtu více proměnných za sebou. Přitom to vůbec není potřeba, protože na správné psaní desetinné čárky máme uvozovkové makro. Při překladu úloh čárka redefinována není, což je správně, na rozdíl od této šablony.