### PR TITLE
Labelsuffix for all figures in probtask

### DIFF
--- a/texmf/tex/latex/fks/fksyearbook.cls
+++ b/texmf/tex/latex/fks/fksyearbook.cls
@@ -216,9 +216,10 @@ A{\bfseries}r}} % sum
     {Úloha \problemnum{solvedbatch}{problem} \,\ldots{} \@probname{} \hfill
       {\normalfont\normalsize\problemstats}}%
 	  \label{solution\thebatch-\theproblem}%
-   \renewcommand\labelsuffix{_sol}\nopagebreak\ifthenelse{\equal{\@probfig}{N/A}}{}{\@probfig}\nopagebreak\renewcommand\labelsuffix{}%
+   \renewcommand\labelsuffix{_sol}\nopagebreak\ifthenelse{\equal{\@probfig}{N/A}}{}{\@probfig}\nopagebreak%
 %   \nopagebreak\ifthenelse{\equal{\@probfig}{N/A}}{}{\@probfig}\nopagebreak%
    \textsl{\@probtask}
+   \renewcommand\labelsuffix{}
    
    \medskip
    


### PR DESCRIPTION
Labelsuffix byl implementován pouze pro obrázky v probfigu. Jakýkoliv jiný obrázek v zadání mimo probfig způsoboval kolize labelu v ročence. Proto by měl být labelsuffix vyresetován až po celém zadání.