### PR TITLE
year score function

### DIFF
--- a/texmf/tex/latex/fks/fksbatch.cls
+++ b/texmf/tex/latex/fks/fksbatch.cls
@@ -93,7 +93,7 @@
 \newcommand\deadlineS[1]{\renewcommand\@deadlineS{#1}}
 
 % recalculates percents from last series' to percents of the whole year
-\def\hotfix#1{
+\def\calcYearPercent#1{
     \newcount\a\a=#1
     \divide \a by 6
     \the\a

--- a/texmf/tex/latex/fks/fksbatch.cls
+++ b/texmf/tex/latex/fks/fksbatch.cls
@@ -92,6 +92,9 @@
 \newcommand\@deadlineS{N/A} % send
 \newcommand\deadlineS[1]{\renewcommand\@deadlineS{#1}}
 
-
-
-
+% recalculates percents from last series' to percents of the whole year
+\def\hotfix#1{
+    \newcount\a\a=#1
+    \divide \a by 6
+    \the\a
+}


### PR DESCRIPTION
Meggy's function
> můj hotfix, který přepočítává procenta za minulé série na procenta za celý ročník

Necessary to make batches -- otherwise making the list of participants will fail. Before it was manually written to every batch*/batch*.tex, which is a bad practice

TODO: rename it. Name `hotfix` is to be avoided. But I don't know, where is it used.