### PR TITLE
Fix * declaration

### DIFF
--- a/texmf/tex/latex/fks/fkssugar.sty
+++ b/texmf/tex/latex/fks/fkssugar.sty
@@ -282,8 +282,7 @@
 \binoppenalty=10000     % nikde jinde se relace lamat nesmeji
 \relpenalty=10000     % nikde jinde se relace lamat nesmeji
 % jednodussi psani \cdot
-\bgroup\uccode`~=`*\uppercase{\egroup\let~}\cdot
-\mathcode`\*="8000
+\DeclareMathSymbol{*}{\mathbin}{symbols}{"01}
 
 % pohodlne psani cisel a jednotek (napr. $ G = "6.672e-11 N.m^2.kg^{-2}" $)
 \begingroup\uccode`~=`e\uppercase{\endgroup\let~}\E   % aktivni e se chova jako \E


### PR DESCRIPTION
Kvůli zadefinování * jako \cdot v matematickém módu přestala v nových verzích texlive fungovat input path pro balíček graphics/graphicx (no idea why). Tohle je pouze redeklarace, která definuje * stejným způsobem, jakým je zadefinován \cdot, a opravuje tuto nekompatibilitu.