### PR TITLE
meta: Use https in 3rd party link too

### DIFF
--- a/texmf/tex/latex/fks/fksmeta.sty
+++ b/texmf/tex/latex/fks/fksmeta.sty
@@ -172,7 +172,7 @@ MFF~UK, jeho zaměstnanci a~Jednotou českých matematiků a~fyziků.
 \footnotesize Toto dílo je šířeno pod licencí Creative Commons
 Attribution-Share Alike 3.0 Unported.\\
 Pro zobrazení kopie této licence navštivte
-\url{http://creativecommons.org/licenses/by-sa/3.0/}.\par
+\url{https://creativecommons.org/licenses/by-sa/3.0/}.\par
 }
 
 \renewcommand\met@address{%
@@ -193,7 +193,7 @@ Pro zobrazení kopie této licence navštivte
 \opt{print}{\includegraphics[height=\baselineskip]{fb_logo.eps}}%
 }\nopagebreak
 
-\href{http://www.facebook.com/FYKOS}{\bfseries\slshape http://www.facebook.com/FYKOS}}\fi
+\href{https://www.facebook.com/FYKOS}{\bfseries\slshape https://www.facebook.com/FYKOS}}\fi
 }
 \fi%iffksczech
 \iffksenglish
@@ -207,7 +207,7 @@ his employees and The Union of Czech Mathematicians and Physicists.
 \footnotesize This work is licensed under Creative Commons
 Attribution-Share Alike 3.0 Unported.\\
 To view a copy of the license, visit
-\url{http://creativecommons.org/licenses/by-sa/3.0/}.\par
+\url{https://creativecommons.org/licenses/by-sa/3.0/}.\par
 }
 
 \renewcommand\met@address{%
@@ -229,7 +229,7 @@ To view a copy of the license, visit
         \opt{print}{\includegraphics[height=\baselineskip]{fb_logo.eps}}%
     }\nopagebreak
 
-\href{http://www.facebook.com/Fykos}{\bfseries\slshape http://www.facebook.com/Fykos}}
+\href{https://www.facebook.com/Fykos}{\bfseries\slshape https://www.facebook.com/Fykos}}
 }
 \fi%iffksenglish
 }% end FYKOS
@@ -412,7 +412,7 @@ To view a copy of the license, visit
   & V Holešovičkách 2\\
   & 180\,00 Praha 8\\
 \noalign{\smallskip}
-  www: & \normalfont\url{http://vyfuk.mff.cuni.cz}\\
+  www: & \normalfont\url{https://vyfuk.mff.cuni.cz}\\
 %  \ifnum\theyear<3 e-mail pro řešení: & \normalfont\mail{vyfuk-reseni@fykos.cz}\\\fi
   e-mail: & \normalfont\mail{vyfuk@vyfuk.mff.cuni.cz}\\
 \end{tabular}
@@ -423,7 +423,7 @@ To view a copy of the license, visit
 \opt{print}{\includegraphics[height=\baselineskip]{fb_logo.eps}}%
 }\nopagebreak
 
-\href{http://www.facebook.com/ksvyfuk}{\bfseries\slshape http://www.facebook.com/ksvyfuk}}
+\href{https://www.facebook.com/ksvyfuk}{\bfseries\slshape https://www.facebook.com/ksvyfuk}}
 }
  
 \renewcommand\met@licence{
@@ -436,7 +436,7 @@ MFF~UK, jejími zaměstnanci a~Jednotou českých matematiků a~fyziků.
 \footnotesize Toto dílo je šířeno pod licencí Creative Commons
 Attribution-Share Alike 3.0 Unported.\\
 Pro zobrazení kopie této licence navštivte
-\url{http://creativecommons.org/licenses/by-sa/3.0/}.\par
+\url{https://creativecommons.org/licenses/by-sa/3.0/}.\par
 }
 
 % results table parameter

--- a/texmf/tex/latex/fks/fksmeta.sty
+++ b/texmf/tex/latex/fks/fksmeta.sty
@@ -229,7 +229,7 @@ To view a copy of the license, visit
         \opt{print}{\includegraphics[height=\baselineskip]{fb_logo.eps}}%
     }\nopagebreak
 
-\href{https://www.facebook.com/Fykos}{\bfseries\slshape https://www.facebook.com/Fykos}}
+\href{https://www.facebook.com/FYKOS}{\bfseries\slshape https://www.facebook.com/FYKOS}}
 }
 \fi%iffksenglish
 }% end FYKOS


### PR DESCRIPTION
The readers will access them most probably via public internet,
therefore encrypt the traffic.