### PR TITLE
Add proborigin macro to the solutions in the yearbook.

### DIFF
--- a/texmf/tex/latex/fks/fksyearbook.cls
+++ b/texmf/tex/latex/fks/fksyearbook.cls
@@ -219,6 +219,7 @@ A{\bfseries}r}} % sum
    \renewcommand\labelsuffix{_sol}\nopagebreak\ifthenelse{\equal{\@probfig}{N/A}}{}{\@probfig}\nopagebreak%
 %   \nopagebreak\ifthenelse{\equal{\@probfig}{N/A}}{}{\@probfig}\nopagebreak%
    \textsl{\@probtask}
+   \signed{\textit{\@proborigin}}
    \renewcommand\labelsuffix{}
    
    \medskip


### PR DESCRIPTION
Proboriginy jsou často vtipné a zajímavé, a by byla škoda neuvádět je v ročence.